### PR TITLE
fix(update): use paging for github repos

### DIFF
--- a/update.py
+++ b/update.py
@@ -306,8 +306,32 @@ def update_github():
     """
     Cache and update GitHub Repo banners.
     """
-    response = s.get(url=f'https://api.github.com/users/{args.github_repository_owner}/repos')
-    repos = response.json()
+    url = f'https://api.github.com/users/{args.github_repository_owner}/repos'
+    per_page = 100
+    repos = []
+
+    headers = dict(
+        accept='application/vnd.github.v3+json',
+    )
+
+    query_params = dict(
+        per_page=per_page,
+        page=1,
+    )
+
+    while True:
+        response = s.get(
+            url=url,
+            headers=headers,
+            params=query_params,
+        )
+        response_data = response.json()
+        repos.extend(response_data)
+
+        if len(response_data) < per_page:
+            break
+
+        query_params['page'] += 1
 
     file_path = os.path.join(BASE_DIR, 'github', 'repos')
     write_json_files(file_path=file_path, data=repos)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
GitHub repos were not paged, so only the first 30 repos would be returned by default. `per_page` is now set to 100, and the code will loop over the pages (if we ever exceed the 100 repositories required to hit that)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
